### PR TITLE
fix: SCALE_UP not having the correct deltaX on next image

### DIFF
--- a/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
+++ b/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
@@ -65,7 +65,6 @@ public class SlideshowWallpaperService extends WallpaperService {
 
         private ImageInfo lastRenderedImage;
 
-        private float deltaX;
         private boolean isScrolling = false;
         private float xOffset = 0f;
         private float xOffsetStep = 0f;
@@ -76,7 +75,6 @@ public class SlideshowWallpaperService extends WallpaperService {
             SharedPreferences prefs = getSharedPreferences();
             manager = new SharedPreferencesManager(prefs);
 
-            deltaX = 0;
             handler = new Handler(Looper.getMainLooper());
             drawRunner = new DrawRunner();
 
@@ -106,6 +104,8 @@ public class SlideshowWallpaperService extends WallpaperService {
 
             this.xOffset = xOffset;
             this.xOffsetStep = xOffsetStep;
+            // When the xOffset is not a whole number, the wallpaper is scrolling
+            isScrolling = (Math.floor(xOffset) != xOffset);
 
             SharedPreferencesManager.TooWideImagesRule rule = manager.getTooWideImagesRule(getResources());
             if (rule != SharedPreferencesManager.TooWideImagesRule.SCROLL_FORWARD && rule != SharedPreferencesManager.TooWideImagesRule.SCROLL_BACKWARD) {
@@ -113,8 +113,6 @@ public class SlideshowWallpaperService extends WallpaperService {
                 return;
             }
 
-            // When the xOffset is not a whole number, the wallpaper is scrolling
-            isScrolling = (Math.floor(xOffset) != xOffset);
             handler.removeCallbacks(drawRunner);
             handler.post(drawRunner);
         }
@@ -219,7 +217,7 @@ public class SlideshowWallpaperService extends WallpaperService {
                         }
                         if (bitmap != null) {
                             SharedPreferencesManager.TooWideImagesRule rule = manager.getTooWideImagesRule(getResources());
-                            deltaX = calculateDeltaX(bitmap, xOffset, xOffsetStep);
+                            float deltaX = calculateDeltaX(bitmap, xOffset, xOffsetStep);
                             boolean antiAlias = manager.getAntiAlias();
                             boolean antiAliasScrolling = manager.getAntiAliasWhileScrolling();
                             imagePaint.setAntiAlias(antiAlias && (!isScrolling || antiAliasScrolling));

--- a/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
+++ b/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
@@ -108,7 +108,7 @@ public class SlideshowWallpaperService extends WallpaperService {
             isScrolling = (Math.floor(xOffset) != xOffset);
 
             SharedPreferencesManager.TooWideImagesRule rule = manager.getTooWideImagesRule(getResources());
-            // We only want to retrigger drawing for scrolling if we have one of the scrolling options enabled
+            // We only need to retrigger a redraw on scroll if we have one of the scrolling options enabled
             if (rule == SharedPreferencesManager.TooWideImagesRule.SCROLL_FORWARD || rule == SharedPreferencesManager.TooWideImagesRule.SCROLL_BACKWARD) {
                 handler.removeCallbacks(drawRunner);
                 handler.post(drawRunner);

--- a/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
+++ b/app/src/main/java/io/github/doubi88/slideshowwallpaper/SlideshowWallpaperService.java
@@ -108,13 +108,11 @@ public class SlideshowWallpaperService extends WallpaperService {
             isScrolling = (Math.floor(xOffset) != xOffset);
 
             SharedPreferencesManager.TooWideImagesRule rule = manager.getTooWideImagesRule(getResources());
-            if (rule != SharedPreferencesManager.TooWideImagesRule.SCROLL_FORWARD && rule != SharedPreferencesManager.TooWideImagesRule.SCROLL_BACKWARD) {
-                // We don't need to retrigger drawing for scrolling if we don't have one of the scrolling settings enabled
-                return;
+            // We only want to retrigger drawing for scrolling if we have one of the scrolling options enabled
+            if (rule == SharedPreferencesManager.TooWideImagesRule.SCROLL_FORWARD || rule == SharedPreferencesManager.TooWideImagesRule.SCROLL_BACKWARD) {
+                handler.removeCallbacks(drawRunner);
+                handler.post(drawRunner);
             }
-
-            handler.removeCallbacks(drawRunner);
-            handler.post(drawRunner);
         }
 
         private float calculateDeltaX(Bitmap image, float xOffset, float xOffsetStep) {


### PR DESCRIPTION
Currently, deltaX is only calculated when a scrolling event happens. This causes the issue that when a new image appears it takes over the deltaX of the previous picture. This can cause a wrong offset and causes the SCALE_UP option to not be centered anymore. With this new approach, the calculation is moved to during the drawing, so when a new picture happens we can guarantee that it will always be properly placed in the center.

I also took the liberty to not do a redraw if we scroll while in the SCALE_UP and SCALE_DOWN setting. Drawing feels somewhat like an expensive task, and those two options don't do anything with the scroll, so it feels unnecessary. But I might miss something, so please tell me if I got this wrong :)